### PR TITLE
Add support for --condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ httpstatus = "0.1"
 flate2 = "1.0"
 colored = "1.9"
 pager = "0.15"
+quick-js = "0.4"
 
 [dev-dependencies]
 bytes = "0.4"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Bunyan Viewer supports the following features:
 
 Bunyan Viewer does not yet support the following:
  * Runtime log snooping via DTrace (`-p` flag)
- * Conditional filtering (`-c, --condition` flag)
 
 ## Installation
 

--- a/src/condition_filter.rs
+++ b/src/condition_filter.rs
@@ -1,0 +1,42 @@
+use core::fmt;
+
+use quick_js::Context;
+
+pub struct ConditionFilter {
+    context: Context,
+    condition: String,
+}
+
+impl ConditionFilter {
+    pub fn new<S>(condition: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            context: Context::new().unwrap(),
+            condition: condition.into(),
+        }
+    }
+    pub fn filter(&self, line: &str) -> bool {
+        self.context
+            .eval_as::<bool>(
+                format!("(function (){{return ({})}}).call({line})", self.condition).as_str(),
+            )
+            .unwrap()
+    }
+}
+
+impl fmt::Debug for ConditionFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ConditionFilter [`{}`]", self.condition)
+    }
+}
+
+impl Clone for ConditionFilter {
+    fn clone(&self) -> Self {
+        Self {
+            context: Context::new().unwrap(),
+            condition: self.condition.clone(),
+        }
+    }
+}

--- a/tests/corpus_test.rs
+++ b/tests/corpus_test.rs
@@ -29,6 +29,7 @@ fn assert_equals_to_file(filename: &str, expected_filename: &str, format: LogFor
         is_debug: false,
         is_strict: false,
         level: None,
+        condition_filter: None,
         display_local_time: false,
         format,
     };


### PR DESCRIPTION
Add support for filtering logs using `--condition`/`-c` like the Javascript version.

This uses `quick-js` as a very small Javascript interpreter so it would theoretically works the same as the original version, while still being 10x faster :sunglasses:  (at least when tested with the benchmark from the original Rust `bunyan`)