### PR TITLE
CI: build for aarch64

### DIFF
--- a/.github/workflows/publish_binaries_to_gh.yaml
+++ b/.github/workflows/publish_binaries_to_gh.yaml
@@ -18,16 +18,22 @@ jobs:
   upload-assets:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-#          - windows-latest
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: bunyan
+          target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           tar: unix
           zip: windows


### PR DESCRIPTION
Build and add to the released binaries for aarch64-unknown-linux-gnu and aarch64-apple-darwin